### PR TITLE
Add Word impls for signed integer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-
 ## [Unreleased]
 
-...
+Added Word impls for signed integer types
 
 ## v0.1.0 - 2020-08-20
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-Added Word impls for signed integer types
+### Added
+- Signed integer type `Word` trait implementations
 
 ## v0.1.0 - 2020-08-20
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,13 @@ where
 pub unsafe trait Word {}
 
 unsafe impl Word for u8 {}
+unsafe impl Word for i8 {}
 unsafe impl Word for u16 {}
+unsafe impl Word for i16 {}
 unsafe impl Word for u32 {}
+unsafe impl Word for i32 {}
 unsafe impl Word for u64 {}
+unsafe impl Word for i64 {}
 
 /// Trait for `Deref` targets used by the blanket `DmaReadBuffer` impl.
 ///


### PR DESCRIPTION
Working on an I2S module for `nrf-hal` using these traits and noticed `Word` impls for signed integer types are missing, so i added them.