### PR TITLE
Prepare 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+...
+
+## [v0.1.1] - 2020-09-04
+
 ### Added
 - Signed integer type `Word` trait implementations
 
@@ -14,4 +18,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.1...HEAD
+[v0.1.1]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-dma"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Jan Teske <jteske@posteo.net>",
     "Thales Fragoso <thales.fragosoz@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 This project is developed and maintained by the [HAL team][team].
 
-# [Documentation](https://docs.rs/embedded-dma)
+## [Documentation](https://docs.rs/embedded-dma)
 
-# Minimum Supported Rust Version (MSRV)
+## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.37.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
-# License
+## License
 
 Licensed under either of
 
@@ -22,13 +22,13 @@ Licensed under either of
 
 at your option.
 
-## Contribution
+### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-## Code of Conduct
+### Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
 Conduct][CoC], the maintainer of this crate, the [HAL team][team], promises


### PR DESCRIPTION
A release with the signed integer implementations would be helpful for https://github.com/nrf-rs/nrf-hal/pull/209