### PR TITLE
Add Static versions for the traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # All generated code should be running on stable now
         rust: [stable]
 
         # The default target we're compiling on and for

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # All generated code should be running on stable now
         rust: [stable]
 
         include:
+          # Test MSRV
+          - rust: 1.37.0
+
           # Test nightly but don't fail
           - rust: nightly
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: [ staging, trying, master ]
+  pull_request:
+
+name: Test Suite
+
+jobs:
+  ci-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # All generated code should be running on stable now
+        rust: [stable]
+
+        include:
+          # Test nightly but don't fail
+          - rust: nightly
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! that use closures to prevent memory corruption.
 //!
 //! If your API also needs a `'static` bound, prefer the use of [StaticReadBuffer] and
-//! [StaticWriteBuffer], they are a stricter version that requires a `'static` lifetime invariant,
+//! [StaticWriteBuffer]. They are a stricter version that requires a `'static` lifetime invariant,
 //! while also allowing end users to __unsafely__ bypass it.
 //!
 //! If you are not sure which version of the traits you should be bounding to in your DMA


### PR DESCRIPTION
This adds and recommends a new stricter variants of the unsafe traits. The new traits also carry an invariant of having a `'static` lifetime,  which is usually required in the most common DMA api because of `mem::forget`.

This is better than just adding a `+ 'static` to the other traits because it still allows end users to unsafely bail out of the `'static` lifetime if they know what they're doing.

CC @Dirbaio