### PR TITLE
Remove static {read,write} buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Initial release
 
 [unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.2.0...HEAD
-[v0.1.3]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.1.3] - 2021-11-26
+**Breaking:**
+- `StaticReadBuffer` and `StaticWriteBuffer` no longer exist. Instead use `ReadBuffer`, `WriteBuffer`.
 
 ### Added
 - Replace less strict `ReadBuffer` and `WriteBuffer` definitions with
@@ -28,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.3...HEAD
+[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.2.0...HEAD
 [v0.1.3]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-**Breaking:**
-- `StaticReadBuffer` and `StaticWriteBuffer` no longer exist. Instead use `ReadBuffer`, `WriteBuffer`.
+### Changed
+- [breaking change] `StaticReadBuffer` and `StaticWriteBuffer` no longer exist. Instead use `ReadBuffer`, `WriteBuffer`.
 
 ### Added
 - Replace less strict `ReadBuffer` and `WriteBuffer` definitions with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.2...HEAD
 [v0.1.2]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.3] - 2021-11-26
+
+### Added
+- Replace less strict `ReadBuffer` and `WriteBuffer` definitions with
+  those of `StaticReadBuffer` and `StaticWriteBuffer`. This removes the separate static
+  traits.
+
 ## [v0.1.2] - 2020-09-30
 
 ### Added
@@ -21,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.2...HEAD
+[unreleased]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.3...HEAD
+[v0.1.3]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/rust-embedded/embedded-dma/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-dma"
-version = "0.2.0"
+version = "0.1.2"
 authors = [
     "Jan Teske <jteske@posteo.net>",
     "Thales Fragoso <thales.fragosoz@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-dma"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     "Jan Teske <jteske@posteo.net>",
     "Thales Fragoso <thales.fragosoz@gmail.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Traits to aid the correct use of buffers in DMA abstractions.
 //!
-//! This library provides the [ReadBuffer] and [WriteBuffer] unsafe traits to be used as bounds to
+//! This library provides the [`ReadBuffer`] and [`WriteBuffer`] unsafe traits to be used as bounds to
 //! buffers types used in DMA operations.
 //!
 //! There are some subtleties to the extent of the guarantees provided by these traits, all of these

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ unsafe impl Word for i64 {}
 /// # Safety
 ///
 /// - `as_read_buffer` must adhere to the safety requirements
-///   documented for `ReadBuffer::read_buffer`.
+///   documented for [`ReadBuffer::read_buffer`].
 pub unsafe trait ReadTarget {
     type Word: Word;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub unsafe trait ReadTarget {
 /// # Safety
 ///
 /// - `as_write_buffer` must adhere to the safety requirements
-///   documented for `WriteBuffer::write_buffer`.
+///   documented for [`WriteBuffer::write_buffer`].
 pub unsafe trait WriteTarget {
     type Word: Word;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! `Self` (with the exception of [`write_buffer`](trait.WriteBuffer.html#tymethod.write_buffer) in
 //! our case). This is to allow types like `Vec`, this restriction doesn't apply to `Self::Target`.
 //!
-//! * [ReadBuffer] and [WriteBuffer] guarantee a stable location for as long as the DMA transfer
+//! * [`ReadBuffer`] and [`WriteBuffer`] guarantee a stable location for as long as the DMA transfer
 //! occurs. Given the intrinsics of `mem::forget` and the Rust language itself, a
 //! 'static lifetime is usually required.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,6 @@
 //! occurs. Given the intrinsics of `mem::forget` and the Rust language itself, a
 //! 'static lifetime is usually required.
 //!
-//! * The end-user can add their custom implementations of [ReadBuffer] and [WriteBuffer] which do
-//! not need to be 'static. This can be useful when DMA transfers use memory on the stack.
-//! Implementing either trait is unsafe, and end-user will need to verify that invariants are
-//! upheld each time the trait is used. This usually means `mem::forget` is not called on the struct
-//! representing the DMA transfer before the DMA transfer is finished. Since the invariants must be
-//! upheld locally, any implemented traits should not be exported.
-//!
 //! The above list is not exhaustive, for a complete set of requirements and guarantees, the
 //! documentation of each trait and method should be analyzed.
 #![no_std]


### PR DESCRIPTION
- Fixes #17
- Fixes #10
- This is essentially a copy of #13 but with the documentation change requirements that were never made. Since the mentioned PR has been stale since March, I found it fair to make another PR.

I am potentially concerned regarding a use case for non-static buffers in the previous docs in the embedded-dma:
> The reason we don't require `'static` in the traits themselves is because it would block implementations that can deal with stack allocated buffers, like APIs that use closures to prevent memory corruption.

Can someone provide an example of an API that use closures to prevent memory corruption? If closures have a valid use case, #18 might be a better option.