### PR TITLE
update MSRV to 1.49.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,5 +5,5 @@ status = [
   "ci-linux (stable, x86_64-unknown-linux-gnu)",
   "ci-linux (stable, thumbv6m-none-eabi)",
   "ci-linux (stable, thumbv7m-none-eabi)",
-  "ci-linux (1.37.0, x86_64-unknown-linux-gnu)",
+  "ci-linux (1.49.0, x86_64-unknown-linux-gnu)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.37.0
+          - rust: 1.49.0
             TARGET: x86_64-unknown-linux-gnu
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.37.0
+          - rust: 1.49.0
 
           # Test nightly but don't fail
           - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-dma"
 
+[package.metadata]
+msrv = "1.49.0"
+
 [dependencies]
 stable_deref_trait = { version = "1.2.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is developed and maintained by the [HAL team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.37.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.49.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
- previous versions cannot be tested on with M1 macs. This makes contributing to the library—especially with manual CI runs—fairly difficult