### PR TITLE
Added SliceWrapper and SliceWrapperMut to allow for DMA with non-static slices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ impl<'a, T> SliceWrapper<'a, T> {
     ///
     /// Here is an example using rp2040-hal:
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut buffer = [0u8; 256];
     /// let mut wrapper = SliceWrapper::new(&mut buffer);
     /// let pointer = wrapper.get_pointer();
@@ -368,7 +368,7 @@ impl<'a, T> SliceWrapperMut<'a, T> {
     ///
     /// Here is an example using rp2040-hal:
     ///
-    /// ```no_run
+    /// ```ignore
     /// let mut buffer = [0u8; 256];
     /// let mut wrapper = SliceWrapperMut::new(&mut buffer);
     /// let pointer = wrapper.get_pointer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl<'a, T> SliceWrapper<'a, T> {
     ///
     /// ```ignore
     /// let mut buffer = [0u8; 256];
-    /// let mut wrapper = SliceWrapper::new(&mut buffer);
+    /// let mut wrapper = unsafe { SliceWrapper::new(&mut buffer) };
     /// let pointer = wrapper.get_pointer();
     /// let transfer = dma::single_buffer::Config::new(dma, pointer, uart_tx).start();
     /// let (dma, pointer, uart_tx) = transfer.wait();
@@ -370,7 +370,7 @@ impl<'a, T> SliceWrapperMut<'a, T> {
     ///
     /// ```ignore
     /// let mut buffer = [0u8; 256];
-    /// let mut wrapper = SliceWrapperMut::new(&mut buffer);
+    /// let mut wrapper = unsafe { SliceWrapperMut::new(&mut buffer) };
     /// let pointer = wrapper.get_pointer();
     /// let transfer = dma::single_buffer::Config::new(dma, pointer, uart_tx).start();
     /// let (dma, pointer, uart_tx) = transfer.wait();


### PR DESCRIPTION
Added some basic structs that allow DMA transfers too and from non-static slices. They are 99% safe, but I did make them unsafe due to them requiring that the destructor be called before dropping.